### PR TITLE
Import de ZP et de mailles au format shp sous Postgre

### DIFF
--- a/data/import_mailles.sql
+++ b/data/import_mailles.sql
@@ -1,0 +1,9 @@
+ALTER TABLE DATABASE_SCHEMA.DATABASE_TABLE  
+ALTER COLUMN geom TYPE geometry(MULTIPOLYGON, MY_SRID_LOCAL) 
+USING ST_Force2D(geom);
+
+INSERT INTO ref_geo.l_areas (id_type, area_name, geom, centroid, source)
+SELECT ref_geo.get_id_area_type('M25m'), cd25M, geom, ST_CENTROID(geom), 'INPN'
+FROM DATABASE_SCHEMA.DATABASE_TABLE;
+
+DROP TABLE DATABASE_SCHEMA.DATABASE_TABLE;

--- a/data/import_zp.sql
+++ b/data/import_zp.sql
@@ -1,0 +1,24 @@
+
+ALTER TABLE DATABASE_SCHEMA.DATABASE_TABLE  
+ALTER COLUMN geom TYPE geometry(MULTIPOLYGON, MY_SRID_LOCAL) 
+USING ST_Force2D(geom);
+
+-- insérer les données dans t_base_sites grâce à celles dans la table zp
+-- ATTENTION: il faut que le fichier shp soit en 2154, sinon ça donne des erreurs pour afficher les Zp.  
+
+INSERT INTO gn_monitoring.t_base_sites
+(id_nomenclature_type_site, base_site_name, base_site_description,  base_site_code, first_use_date, geom )
+SELECT ref_nomenclatures.get_id_nomenclature('TYPE_SITE', 'ZP'), 'ZP-', '', idzp, now(), ST_TRANSFORM(ST_SetSRID(geom, MY_SRID_LOCAL), MY_SRID_WORLD)
+FROM DATABASE_SCHEMA.DATABASE_TABLE;
+
+--- update le nom du site pour y ajouter l'identifiant du site
+UPDATE gn_monitoring.t_base_sites SET base_site_name=CONCAT (base_site_name, base_site_code); 
+
+
+-- extension de la table t_base_sites : mettre les données dans t_infos_site
+INSERT INTO pr_monitoring_flora_territory.t_infos_site (id_base_site, cd_nom)
+SELECT bs.id_base_site, zp.cd_nom
+FROM gn_monitoring.t_base_sites bs
+JOIN DATABASE_SCHEMA.DATABASE_TABLE zp ON zp.idzp::character varying = bs.base_site_code;
+
+DROP TABLE DATABASE_SCHEMA.DATABASE_TABLE;

--- a/import_mailles.sh
+++ b/import_mailles.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+DATABASE_SCHEMA="pr_monitoring_flora_territory"
+
+. config/settings.ini
+
+# Remove previous log file
+
+rm var/log/sft_mailles.log
+
+echo -n "Chemin complet de votre shape ?"
+read MYPATH
+echo -n "Quel est le nom de votre shape ?"
+read DATABASE_TABLE
+
+# Copy SQL file into /tmp system folder in order to edit it with variables
+
+cp data/import_mailles.sql /tmp/import_mailles.sql
+
+sudo sed -i "s/MY_SRID_LOCAL/$srid_local/g" /tmp/import_mailles.sql
+sudo sed -i "s/MY_SRID_WORLD/$srid_world/g" /tmp/import_mailles.sql
+sudo sed -i "s/DATABASE_SCHEMA/$DATABASE_SCHEMA/g" /tmp/import_mailles.sql
+sudo sed -i "s/DATABASE_TABLE/$DATABASE_TABLE/g" /tmp/import_mailles.sql
+
+# Export SHP maille to PostGis and create table maille
+
+sudo -n -u postgres shp2pgsql -s 2154 -c "$MYPATH/$DATABASE_TABLE.shp" $DATABASE_SCHEMA.$DATABASE_TABLE | psql -d $db_name -h localhost -U $user_pg &>> var/log/sft_mailles.log
+
+# Insert data into ref_geo.l_areas
+
+export PGPASSWORD=$user_pg_pass;psql -h $db_host -U $user_pg -d $db_name -f /tmp/import_mailles.sql  &>> var/log/sft_mailles.log         
+
+# Remove SQL temporary file
+
+rm /tmp/import_mailles.sql

--- a/import_zp.sh
+++ b/import_zp.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+DATABASE_SCHEMA="pr_monitoring_flora_territory"
+
+. config/settings.ini
+
+# Remove previous log file
+
+rm var/log/sft_zp.log
+
+echo -n "Chemin complet de votre shape ?"
+read MYPATH
+echo -n "Quel est le nom de votre shape ?"
+read DATABASE_TABLE
+
+# Copy SQL files into /tmp system folder in order to edit it with variables
+
+cp data/import_zp.sql /tmp/import_zp.sql
+
+sudo sed -i "s/MY_SRID_LOCAL/$srid_local/g" /tmp/import_zp.sql
+sudo sed -i "s/MY_SRID_WORLD/$srid_world/g" /tmp/import_zp.sql
+sudo sed -i "s/DATABASE_SCHEMA/$DATABASE_SCHEMA/g" /tmp/import_zp.sql
+sudo sed -i "s/DATABASE_TABLE/$DATABASE_TABLE/g" /tmp/import_zp.sql
+
+# Export SHP maille to PostGis and create table zp
+
+sudo -n -u postgres shp2pgsql -s 2154 -c "$MYPATH/$DATABASE_TABLE.shp" $DATABASE_SCHEMA.$DATABASE_TABLE | psql -d $db_name -h localhost -U $user_pg &>> var/log/sft_zp.log
+
+# Insert data into ref_geo.l_areas
+
+export PGPASSWORD=$user_pg_pass;psql -h $db_host -U $user_pg -d $db_name -f /tmp/import_zp.sql &>> var/log/sft_zp.log
+
+# Remove SQL temporary file
+
+rm /tmp/import_zp.sql


### PR DESCRIPTION
Fichiers réalisés avec les fichiers .shp du CBNA.

A configurer dans install_db.sh pour l'exécution ou en autonomie lors de campagnes d'ajout de mailles et de ZP.